### PR TITLE
Comprehensive CHIP-8 emulator test suite and CPU fixes

### DIFF
--- a/chipee.c
+++ b/chipee.c
@@ -1,5 +1,6 @@
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 #include <time.h>
 #include "chipee.h"
 
@@ -61,12 +62,33 @@ unsigned char draw_flag = 0;
 // whether we need to play a sound in this cycle
 unsigned char sound_flag = 0;
 
+// previous keypad state for detecting key releases (used by FX0A)
+unsigned char prev_keypad[16] = {0};
+// key being waited on for FX0A (-1 = not waiting)
+signed char waiting_for_key = -1;
+
 void init_cpu() {
     srand((unsigned int) time(NULL));
 
-    // load fonts:
+    // reset all state
+    memset(memory, 0, sizeof(memory));
+    memset(V, 0, sizeof(V));
+    memset(gfx, 0, sizeof(gfx));
+    memset(stack, 0, sizeof(stack));
+    memset(keypad, 0, sizeof(keypad));
+    memset(prev_keypad, 0, sizeof(prev_keypad));
+    I = 0;
+    pc = 0x200;
+    sp = 0;
+    delay_timer = 0;
+    sound_timer = 0;
+    draw_flag = 0;
+    sound_flag = 0;
+    waiting_for_key = -1;
+
+    // load fonts at 0x050:
     for (int i = 0; i < 80; i++) {
-        memory[i] = chip8_fontset[i];
+        memory[0x50 + i] = chip8_fontset[i];
     }
 }
 
@@ -74,13 +96,14 @@ int check_rom(char* filename) {
     FILE* fileptr;
 
     if ((fileptr = fopen(filename, "rb"))) {
+        fclose(fileptr);
         return 1;
     } else {
         return 0;
     }
 }
 
-void load_rom(char* filename) {
+int load_rom(char* filename) {
     FILE* fileptr = fopen(filename, "rb");
 
     // get size of the file for malloc:
@@ -88,7 +111,13 @@ void load_rom(char* filename) {
     long buffer_size = ftell(fileptr);
     rewind(fileptr);
 
-    char* buffer = (char*) malloc((buffer_size + 1) * sizeof(char)); // enough memory for file + \0
+    if (buffer_size > 4096 - 512) {
+        printf("ROM too large! Max size is %d bytes, got %ld bytes.\n", 4096 - 512, buffer_size);
+        fclose(fileptr);
+        return 0;
+    }
+
+    char* buffer = (char*) malloc(buffer_size * sizeof(char));
     fread(buffer, buffer_size, 1, fileptr);
     fclose(fileptr);
 
@@ -97,6 +126,7 @@ void load_rom(char* filename) {
     }
 
     free(buffer);
+    return 1;
 }
 
 void emulate_cycle() {
@@ -113,11 +143,16 @@ void emulate_cycle() {
                     for (int i = 0; i < 64 * 32; i++) {
                         gfx[i] = 0;
                     }
+                    draw_flag = 1;
                     pc += 2;
                     break;
                 case 0x00EE: // 0x00EE: return from subroutine
-                    pc = stack[sp];
+                    if (sp == 0) {
+                        printf("Stack underflow!\n");
+                        break;
+                    }
                     sp--;
+                    pc = stack[sp];
                     pc += 2;
                     break;
                 default:
@@ -129,8 +164,12 @@ void emulate_cycle() {
             pc = op & 0x0FFF;
             break;
         case 0x2000: // 0x2NNN: call subroutine at NNN
+            if (sp >= 16) {
+                printf("Stack overflow!\n");
+                break;
+            }
+            stack[sp] = pc; // store return address
             sp++; // increment the position we are at on the stack
-            stack[sp] = pc; // we will need to return eventually, so keep our counter in the stack
             pc = op & 0x0FFF;
             break;
         case 0x3000: // 0x3XNN: skip next instruction if V[x] == NN
@@ -168,56 +207,55 @@ void emulate_cycle() {
                     break;
                 case 0x0001: // 0x8XY1: set V[x] = V[x] OR V[y]
                     V[x] = V[x] | V[y];
+                    V[0xF] = 0;
                     pc += 2;
                     break;
                 case 0x0002: // 0x8XY2: set V[x] = V[x] AND V[y]
                     V[x] = V[x] & V[y];
+                    V[0xF] = 0;
                     pc += 2;
                     break;
                 case 0x0003: // 0x8XY3: set V[x] = V[x] XOR V[y]
                     V[x] = V[x] ^ V[y];
+                    V[0xF] = 0;
                     pc += 2;
                     break;
-                case 0x0004: // 0x8XY4: set V[x] = V[x] + V[y], set V[F] = carry
-                    V[0xF] = 0;
-                    if ((V[x] + V[y]) > 0xFF) {
-                        V[0xF] = 1;
-                    }
-                    V[x] += V[y];
+                case 0x0004: { // 0x8XY4: set V[x] = V[x] + V[y], set V[F] = carry
+                    unsigned short sum = V[x] + V[y];
+                    unsigned char carry = (sum > 0xFF) ? 1 : 0;
+                    V[x] = sum & 0xFF;
+                    V[0xF] = carry;
                     pc += 2;
                     break;
-                case 0x0005: // 0x8XY5: set V[x] = V[x] - V[y], set V[F] = NOT borrow
-                    // If V[x] > V[y], set V[F] to 1, otherwise 0.
-                    // Then set V[x] = V[x] - V[y]
-                    V[0xF] = 0;
-                    if (V[x] > V[y]) {
-                        V[0xF] = 1;
-                    }
+                }
+                case 0x0005: { // 0x8XY5: set V[x] = V[x] - V[y], set V[F] = NOT borrow
+                    unsigned char not_borrow = (V[x] >= V[y]) ? 1 : 0;
                     V[x] -= V[y];
+                    V[0xF] = not_borrow;
                     pc += 2;
                     break;
-                case 0x0006: // 0x8XY6: set V[x] = V[x] SHR 1
-                    // Set V[F] to the remainder of dividing by 2, then divide V[x] by 2
-                    V[0xF] = V[x] % 2;
-                    V[x] /= 2;
+                }
+                case 0x0006: { // 0x8XY6: set V[x] = V[x] SHR 1
+                    unsigned char lsb = V[x] & 1;
+                    V[x] >>= 1;
+                    V[0xF] = lsb;
                     pc += 2;
                     break;
-                case 0x0007: // 0x8XY7: set V[x] = V[y] - V[x], set V[F] = NOT borrow
-                    // If V[y] > V[x], set V[F] to 1, otherwise 0. Then set V[x] = V[y] - V[x]
-                    V[0xF] = 0;
-                    if (V[y] > V[x]) {
-                        V[0xF] = 1;
-                    }
+                }
+                case 0x0007: { // 0x8XY7: set V[x] = V[y] - V[x], set V[F] = NOT borrow
+                    unsigned char not_borrow = (V[y] >= V[x]) ? 1 : 0;
                     V[x] = V[y] - V[x];
+                    V[0xF] = not_borrow;
                     pc += 2;
                     break;
-                case 0x000E: // 0x8XYE: Set V[x] = V[x] SHL 1
-                    // If the most-significant bit of V[x] is 1, set V[F] to 1,
-                    // otherwise set to 0. Then V[x] is multiplied by 2.
-                    V[0xF] = (V[x] >> 7);
-                    V[x] *= 2;
+                }
+                case 0x000E: { // 0x8XYE: Set V[x] = V[x] SHL 1
+                    unsigned char msb = (V[x] >> 7) & 1;
+                    V[x] <<= 1;
+                    V[0xF] = msb;
                     pc += 2;
                     break;
+                }
                 default:
                     printf("Unknown op: 0x%X\n", op);
                     break;
@@ -257,16 +295,21 @@ void emulate_cycle() {
 
             unsigned short height = op & 0x000F;
             unsigned short pixel;
+            unsigned char x_coord = V[x] % 64;
+            unsigned char y_coord = V[y] % 32;
 
             V[0xF] = 0;
             for (int yline = 0; yline < height; yline++) {
+                if (y_coord + yline >= 32) break; // clip vertically
                 pixel = memory[I + yline];
                 for (int xline = 0; xline < 8; xline++) {
+                    if (x_coord + xline >= 64) break; // clip horizontally
                     if ((pixel & (0x80 >> xline)) != 0) {
-                        if (gfx[(V[x] + xline + ((V[y] + yline) * 64))] == 1) {
+                        int idx = (x_coord + xline) + ((y_coord + yline) * 64);
+                        if (gfx[idx] == 1) {
                             V[0xF] = 1;
                         }
-                        gfx[V[x] + xline + ((V[y] + yline) * 64)] ^= 1;
+                        gfx[idx] ^= 1;
                     }
                 }
             }
@@ -297,12 +340,21 @@ void emulate_cycle() {
                     V[x] = delay_timer;
                     pc += 2;
                     break;
-                case 0x000A: // 0xFX0A: wait for a key press, then store the value of the key in V[x]
-                    for (int i = 0; i < 16; i++) {
-                        if (keypad[i]) {
-                            V[x] = i;
+                case 0x000A: // 0xFX0A: wait for a key press then release
+                    if (waiting_for_key >= 0) {
+                        // waiting for key release
+                        if (!keypad[(int)waiting_for_key]) {
+                            V[x] = waiting_for_key;
+                            waiting_for_key = -1;
                             pc += 2;
-                            break;
+                        }
+                    } else {
+                        // waiting for key press
+                        for (int i = 0; i < 16; i++) {
+                            if (keypad[i] && !prev_keypad[i]) {
+                                waiting_for_key = i;
+                                break;
+                            }
                         }
                     }
                     break;
@@ -319,7 +371,7 @@ void emulate_cycle() {
                     pc += 2;
                     break;
                 case 0x0029: // 0xFX29: set I = location of sprite for digit V[x]
-                    I = V[x] * 5; // each digit is 5 bytes long
+                    I = 0x50 + (V[x] * 5); // each digit is 5 bytes, starting at 0x050
                     pc += 2;
                     break;
                 case 0x0033: // 0xFX33: store BCD(V[x]) in I, I+1, I+2
@@ -354,14 +406,19 @@ void emulate_cycle() {
             break;
     }
 
-    // update delay timer
+}
+
+void update_timers() {
     if (delay_timer > 0) {
         delay_timer--;
     }
 
-    // beep and update sound timer
     if (sound_timer > 0) {
         sound_flag = 1;
         sound_timer--;
     }
+}
+
+void update_prev_keypad() {
+    memcpy(prev_keypad, keypad, sizeof(keypad));
 }

--- a/chipee.h
+++ b/chipee.h
@@ -10,6 +10,8 @@ extern unsigned char gfx[64 * 32];
 extern unsigned short stack[16];
 extern unsigned short sp;
 extern unsigned char keypad[16];
+extern unsigned char prev_keypad[16];
+extern signed char waiting_for_key;
 extern unsigned char delay_timer;
 extern unsigned char sound_timer;
 extern unsigned char draw_flag;
@@ -17,7 +19,9 @@ extern unsigned char sound_flag;
 
 void init_cpu();
 int check_rom(char* filename);
-void load_rom(char* filename);
+int load_rom(char* filename);
 void emulate_cycle();
+void update_timers();
+void update_prev_keypad();
 
 #endif

--- a/chipee_tests.c
+++ b/chipee_tests.c
@@ -1,70 +1,701 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include "chipee.h"
 
-#define TEST_ROM_LEN 6
-unsigned char test_rom[TEST_ROM_LEN] = {
-        0x65, 0xF1, 0x62, 0x08, 0xA2, 0x20
-};
+static int tests_passed = 0;
+static int tests_failed = 0;
 
-void load_test_rom() {
-    for (int i = 0; i < TEST_ROM_LEN; i++) {
-        memory[512 + i] = test_rom[i]; // first 512 bytes are reserved
-    }
+#define ASSERT_EQ(desc, actual, expected) do { \
+    if ((actual) == (expected)) { \
+        tests_passed++; \
+    } else { \
+        tests_failed++; \
+        printf("  FAILED: %s (expected 0x%X, got 0x%X)\n", desc, (unsigned int)(expected), (unsigned int)(actual)); \
+    } \
+} while(0)
+
+// Helper: reset CPU and inject a single opcode at 0x200
+static void setup(unsigned char hi, unsigned char lo) {
+    init_cpu();
+    memory[0x200] = hi;
+    memory[0x201] = lo;
 }
 
-int main(int argc, char **argv) {
-    // initialize CPU
+// Helper: inject opcode at a specific address
+static void inject(unsigned short addr, unsigned char hi, unsigned char lo) {
+    memory[addr] = hi;
+    memory[addr + 1] = lo;
+}
+
+// ==================== Initialization ====================
+
+void test_init() {
+    printf("== Initialization ==\n");
     init_cpu();
+    ASSERT_EQ("pc starts at 0x200", pc, 0x200);
+    ASSERT_EQ("sp starts at 0", sp, 0);
+    ASSERT_EQ("I starts at 0", I, 0);
+    ASSERT_EQ("V[0] starts at 0", V[0], 0);
+    ASSERT_EQ("V[0xF] starts at 0", V[0xF], 0);
+    ASSERT_EQ("delay_timer starts at 0", delay_timer, 0);
+    ASSERT_EQ("sound_timer starts at 0", sound_timer, 0);
+    ASSERT_EQ("draw_flag starts at 0", draw_flag, 0);
+    // fonts loaded at 0x050
+    ASSERT_EQ("font '0' at 0x050", memory[0x50], 0xF0);
+    ASSERT_EQ("font 'F' last byte at 0x09F", memory[0x9F], 0x80);
+}
 
-    // assert pc = 0x200
-    printf("TEST: Assert pc = 0x200 at startup...\n");
-    if (pc != 0x200) {
-        printf("FAILED!\n");
-        printf("pc == 0x%X\n", pc);
-        return 1;
-    } else {
-        printf("PASSED!\n");
-    }
+// ==================== 00E0: Clear Screen ====================
 
-    load_test_rom();
-
-    printf("TEST: Test pc = 0x202 after one instruction...\n");
+void test_00E0() {
+    printf("== 00E0: CLS ==\n");
+    setup(0x00, 0xE0);
+    gfx[0] = 1;
+    gfx[100] = 1;
+    gfx[64 * 32 - 1] = 1;
     emulate_cycle();
-    if (pc != 0x202) {
-        printf("FAILED!\n");
-        printf("pc == 0x%X\n", pc);
-        return 1;
-    } else {
-        printf("PASSED!\n");
-    }
+    ASSERT_EQ("gfx[0] cleared", gfx[0], 0);
+    ASSERT_EQ("gfx[100] cleared", gfx[100], 0);
+    ASSERT_EQ("gfx[last] cleared", gfx[64 * 32 - 1], 0);
+    ASSERT_EQ("draw_flag set", draw_flag, 1);
+    ASSERT_EQ("pc advanced", pc, 0x202);
+}
 
-    printf("TEST: LD Vx, byte | 0x65F1 | V[5] == 0xF1\n");
-    if (V[5] != 0xF1) {
-        printf("FAILED!\n");
-        printf("V[5] == 0x%x\n", V[5]);
-    } else {
-        printf("PASSED!\n");
-    }
+// ==================== 00EE / 2NNN: Call & Return ====================
 
-    printf("TEST: Test 0x6XNN: Set V[X] = NN\n");
+void test_2NNN_00EE() {
+    printf("== 2NNN/00EE: CALL & RET ==\n");
+    setup(0x24, 0x00);  // CALL 0x400
+    inject(0x400, 0x00, 0xEE);  // RET at 0x400
+    emulate_cycle();  // execute CALL
+    ASSERT_EQ("CALL: pc jumps to 0x400", pc, 0x400);
+    ASSERT_EQ("CALL: sp is 1", sp, 1);
+    ASSERT_EQ("CALL: stack[0] has return addr", stack[0], 0x200);
+
+    emulate_cycle();  // execute RET
+    ASSERT_EQ("RET: pc returns to 0x202", pc, 0x202);
+    ASSERT_EQ("RET: sp back to 0", sp, 0);
+}
+
+void test_nested_calls() {
+    printf("== Nested CALL/RET ==\n");
+    setup(0x24, 0x00);           // 0x200: CALL 0x400
+    inject(0x202, 0x00, 0x00);   // 0x202: NOP (will be skipped)
+    inject(0x400, 0x25, 0x00);   // 0x400: CALL 0x500
+    inject(0x500, 0x00, 0xEE);   // 0x500: RET
+    inject(0x402, 0x00, 0xEE);   // 0x402: RET
+
+    emulate_cycle();  // CALL 0x400
+    ASSERT_EQ("nested: sp=1 after first CALL", sp, 1);
+    emulate_cycle();  // CALL 0x500
+    ASSERT_EQ("nested: sp=2 after second CALL", sp, 2);
+    emulate_cycle();  // RET from 0x500
+    ASSERT_EQ("nested: pc=0x402 after first RET", pc, 0x402);
+    ASSERT_EQ("nested: sp=1 after first RET", sp, 1);
+    emulate_cycle();  // RET from 0x400
+    ASSERT_EQ("nested: pc=0x202 after second RET", pc, 0x202);
+    ASSERT_EQ("nested: sp=0 after second RET", sp, 0);
+}
+
+// ==================== 1NNN: Jump ====================
+
+void test_1NNN() {
+    printf("== 1NNN: JP ==\n");
+    setup(0x13, 0x50);  // JP 0x350
     emulate_cycle();
-    if (V[2] != 0x08) {
-        printf("FAILED!\n");
-        printf("V[5] == 0x%x\n", V[5]);
-    } else {
-        printf("PASSED!\n");
-    }
+    ASSERT_EQ("JP: pc = 0x350", pc, 0x350);
+}
 
-    printf("TEST: Test 0ANNN\n");
+// ==================== 3XNN: Skip if VX == NN ====================
+
+void test_3XNN() {
+    printf("== 3XNN: SE Vx, byte ==\n");
+    setup(0x63, 0x42);  // LD V3, 0x42
     emulate_cycle();
-    if (I != 0x220) {
-        printf("FAILED!\n");
-        printf("I == 0x%x\n", I);
-    } else {
-        printf("PASSED!\n");
-    }
+    inject(0x202, 0x33, 0x42);  // SE V3, 0x42 (should skip)
+    emulate_cycle();
+    ASSERT_EQ("SE skip: pc = 0x206", pc, 0x206);
 
-    printf("ALL TESTS PASSED!\n");
-    return 0;
+    setup(0x63, 0x42);
+    emulate_cycle();
+    inject(0x202, 0x33, 0x99);  // SE V3, 0x99 (should not skip)
+    emulate_cycle();
+    ASSERT_EQ("SE no skip: pc = 0x204", pc, 0x204);
+}
+
+// ==================== 4XNN: Skip if VX != NN ====================
+
+void test_4XNN() {
+    printf("== 4XNN: SNE Vx, byte ==\n");
+    setup(0x63, 0x42);
+    emulate_cycle();
+    inject(0x202, 0x43, 0x99);  // SNE V3, 0x99 (should skip)
+    emulate_cycle();
+    ASSERT_EQ("SNE skip: pc = 0x206", pc, 0x206);
+
+    setup(0x63, 0x42);
+    emulate_cycle();
+    inject(0x202, 0x43, 0x42);  // SNE V3, 0x42 (should not skip)
+    emulate_cycle();
+    ASSERT_EQ("SNE no skip: pc = 0x204", pc, 0x204);
+}
+
+// ==================== 5XY0: Skip if VX == VY ====================
+
+void test_5XY0() {
+    printf("== 5XY0: SE Vx, Vy ==\n");
+    setup(0x61, 0x0A);  // LD V1, 0x0A
+    inject(0x202, 0x62, 0x0A);  // LD V2, 0x0A
+    inject(0x204, 0x51, 0x20);  // SE V1, V2 (equal, skip)
+    emulate_cycle(); emulate_cycle(); emulate_cycle();
+    ASSERT_EQ("SE Vx==Vy skip: pc = 0x208", pc, 0x208);
+
+    setup(0x61, 0x0A);
+    inject(0x202, 0x62, 0x0B);  // LD V2, 0x0B
+    inject(0x204, 0x51, 0x20);  // SE V1, V2 (not equal, no skip)
+    emulate_cycle(); emulate_cycle(); emulate_cycle();
+    ASSERT_EQ("SE Vx!=Vy no skip: pc = 0x206", pc, 0x206);
+}
+
+// ==================== 6XNN: Load immediate ====================
+
+void test_6XNN() {
+    printf("== 6XNN: LD Vx, byte ==\n");
+    setup(0x6A, 0xFF);  // LD VA, 0xFF
+    emulate_cycle();
+    ASSERT_EQ("LD VA = 0xFF", V[0xA], 0xFF);
+    ASSERT_EQ("pc advanced", pc, 0x202);
+}
+
+// ==================== 7XNN: Add immediate ====================
+
+void test_7XNN() {
+    printf("== 7XNN: ADD Vx, byte ==\n");
+    setup(0x63, 0x10);  // LD V3, 0x10
+    inject(0x202, 0x73, 0x05);  // ADD V3, 0x05
+    emulate_cycle(); emulate_cycle();
+    ASSERT_EQ("ADD: V3 = 0x15", V[3], 0x15);
+
+    // test wrap (no carry flag set)
+    setup(0x63, 0xFF);
+    inject(0x202, 0x73, 0x02);  // ADD V3, 0x02 (wraps)
+    emulate_cycle(); emulate_cycle();
+    ASSERT_EQ("ADD wrap: V3 = 0x01", V[3], 0x01);
+    ASSERT_EQ("ADD wrap: VF unchanged", V[0xF], 0);
+}
+
+// ==================== 8XY0: LD Vx, Vy ====================
+
+void test_8XY0() {
+    printf("== 8XY0: LD Vx, Vy ==\n");
+    setup(0x61, 0x42);  // LD V1, 0x42
+    inject(0x202, 0x82, 0x10);  // LD V2, V1
+    emulate_cycle(); emulate_cycle();
+    ASSERT_EQ("LD V2 = V1 = 0x42", V[2], 0x42);
+}
+
+// ==================== 8XY1: OR ====================
+
+void test_8XY1() {
+    printf("== 8XY1: OR Vx, Vy ==\n");
+    setup(0x61, 0x0F);
+    inject(0x202, 0x62, 0xF0);
+    inject(0x204, 0x81, 0x21);  // OR V1, V2
+    emulate_cycle(); emulate_cycle(); emulate_cycle();
+    ASSERT_EQ("OR: V1 = 0xFF", V[1], 0xFF);
+    ASSERT_EQ("OR: VF reset to 0", V[0xF], 0);
+}
+
+// ==================== 8XY2: AND ====================
+
+void test_8XY2() {
+    printf("== 8XY2: AND Vx, Vy ==\n");
+    setup(0x61, 0x0F);
+    inject(0x202, 0x62, 0xF0);
+    inject(0x204, 0x81, 0x22);  // AND V1, V2
+    emulate_cycle(); emulate_cycle(); emulate_cycle();
+    ASSERT_EQ("AND: V1 = 0x00", V[1], 0x00);
+    ASSERT_EQ("AND: VF reset to 0", V[0xF], 0);
+}
+
+// ==================== 8XY3: XOR ====================
+
+void test_8XY3() {
+    printf("== 8XY3: XOR Vx, Vy ==\n");
+    setup(0x61, 0xFF);
+    inject(0x202, 0x62, 0x0F);
+    inject(0x204, 0x81, 0x23);  // XOR V1, V2
+    emulate_cycle(); emulate_cycle(); emulate_cycle();
+    ASSERT_EQ("XOR: V1 = 0xF0", V[1], 0xF0);
+    ASSERT_EQ("XOR: VF reset to 0", V[0xF], 0);
+}
+
+// ==================== 8XY4: ADD with carry ====================
+
+void test_8XY4() {
+    printf("== 8XY4: ADD Vx, Vy (carry) ==\n");
+    // no overflow
+    setup(0x61, 0x10);
+    inject(0x202, 0x62, 0x20);
+    inject(0x204, 0x81, 0x24);  // ADD V1, V2
+    emulate_cycle(); emulate_cycle(); emulate_cycle();
+    ASSERT_EQ("ADD no carry: V1 = 0x30", V[1], 0x30);
+    ASSERT_EQ("ADD no carry: VF = 0", V[0xF], 0);
+
+    // overflow
+    setup(0x61, 0xFF);
+    inject(0x202, 0x62, 0x02);
+    inject(0x204, 0x81, 0x24);
+    emulate_cycle(); emulate_cycle(); emulate_cycle();
+    ASSERT_EQ("ADD carry: V1 = 0x01", V[1], 0x01);
+    ASSERT_EQ("ADD carry: VF = 1", V[0xF], 1);
+}
+
+void test_8XY4_vf_as_operand() {
+    printf("== 8XY4: ADD VF edge case ==\n");
+    // When X=0xF, VF should hold carry after operation
+    setup(0x6F, 0xFF);  // LD VF, 0xFF
+    inject(0x202, 0x61, 0x02);  // LD V1, 0x02
+    inject(0x204, 0x8F, 0x14);  // ADD VF, V1 (0xFF + 0x02 = overflow)
+    emulate_cycle(); emulate_cycle(); emulate_cycle();
+    ASSERT_EQ("ADD VF edge: VF = 1 (carry wins)", V[0xF], 1);
+}
+
+// ==================== 8XY5: SUB with borrow ====================
+
+void test_8XY5() {
+    printf("== 8XY5: SUB Vx, Vy ==\n");
+    // no borrow
+    setup(0x61, 0x10);
+    inject(0x202, 0x62, 0x05);
+    inject(0x204, 0x81, 0x25);  // SUB V1, V2
+    emulate_cycle(); emulate_cycle(); emulate_cycle();
+    ASSERT_EQ("SUB no borrow: V1 = 0x0B", V[1], 0x0B);
+    ASSERT_EQ("SUB no borrow: VF = 1", V[0xF], 1);
+
+    // borrow
+    setup(0x61, 0x05);
+    inject(0x202, 0x62, 0x10);
+    inject(0x204, 0x81, 0x25);
+    emulate_cycle(); emulate_cycle(); emulate_cycle();
+    ASSERT_EQ("SUB borrow: V1 = 0xF5", V[1], 0xF5);
+    ASSERT_EQ("SUB borrow: VF = 0", V[0xF], 0);
+
+    // equal (no borrow, VF = 1)
+    setup(0x61, 0x42);
+    inject(0x202, 0x62, 0x42);
+    inject(0x204, 0x81, 0x25);
+    emulate_cycle(); emulate_cycle(); emulate_cycle();
+    ASSERT_EQ("SUB equal: V1 = 0", V[1], 0);
+    ASSERT_EQ("SUB equal: VF = 1", V[0xF], 1);
+}
+
+// ==================== 8XY6: SHR ====================
+
+void test_8XY6() {
+    printf("== 8XY6: SHR Vx ==\n");
+    // LSB = 1
+    setup(0x61, 0x07);  // V1 = 0b00000111
+    inject(0x202, 0x81, 0x06);  // SHR V1
+    emulate_cycle(); emulate_cycle();
+    ASSERT_EQ("SHR: V1 = 0x03", V[1], 0x03);
+    ASSERT_EQ("SHR: VF = 1 (LSB)", V[0xF], 1);
+
+    // LSB = 0
+    setup(0x61, 0x04);  // V1 = 0b00000100
+    inject(0x202, 0x81, 0x06);
+    emulate_cycle(); emulate_cycle();
+    ASSERT_EQ("SHR: V1 = 0x02", V[1], 0x02);
+    ASSERT_EQ("SHR: VF = 0 (LSB)", V[0xF], 0);
+}
+
+// ==================== 8XY7: SUBN ====================
+
+void test_8XY7() {
+    printf("== 8XY7: SUBN Vx, Vy ==\n");
+    // Vy > Vx (no borrow)
+    setup(0x61, 0x05);
+    inject(0x202, 0x62, 0x10);
+    inject(0x204, 0x81, 0x27);  // SUBN V1, V2 (V1 = V2 - V1)
+    emulate_cycle(); emulate_cycle(); emulate_cycle();
+    ASSERT_EQ("SUBN no borrow: V1 = 0x0B", V[1], 0x0B);
+    ASSERT_EQ("SUBN no borrow: VF = 1", V[0xF], 1);
+
+    // Vy < Vx (borrow)
+    setup(0x61, 0x10);
+    inject(0x202, 0x62, 0x05);
+    inject(0x204, 0x81, 0x27);
+    emulate_cycle(); emulate_cycle(); emulate_cycle();
+    ASSERT_EQ("SUBN borrow: V1 = 0xF5", V[1], 0xF5);
+    ASSERT_EQ("SUBN borrow: VF = 0", V[0xF], 0);
+
+    // equal (no borrow, VF = 1)
+    setup(0x61, 0x42);
+    inject(0x202, 0x62, 0x42);
+    inject(0x204, 0x81, 0x27);
+    emulate_cycle(); emulate_cycle(); emulate_cycle();
+    ASSERT_EQ("SUBN equal: V1 = 0", V[1], 0);
+    ASSERT_EQ("SUBN equal: VF = 1", V[0xF], 1);
+}
+
+// ==================== 8XYE: SHL ====================
+
+void test_8XYE() {
+    printf("== 8XYE: SHL Vx ==\n");
+    // MSB = 1
+    setup(0x61, 0x81);  // V1 = 0b10000001
+    inject(0x202, 0x81, 0x0E);  // SHL V1
+    emulate_cycle(); emulate_cycle();
+    ASSERT_EQ("SHL: V1 = 0x02", V[1], 0x02);
+    ASSERT_EQ("SHL: VF = 1 (MSB)", V[0xF], 1);
+
+    // MSB = 0
+    setup(0x61, 0x41);  // V1 = 0b01000001
+    inject(0x202, 0x81, 0x0E);
+    emulate_cycle(); emulate_cycle();
+    ASSERT_EQ("SHL: V1 = 0x82", V[1], 0x82);
+    ASSERT_EQ("SHL: VF = 0 (MSB)", V[0xF], 0);
+}
+
+// ==================== 9XY0: Skip if VX != VY ====================
+
+void test_9XY0() {
+    printf("== 9XY0: SNE Vx, Vy ==\n");
+    setup(0x61, 0x0A);
+    inject(0x202, 0x62, 0x0B);
+    inject(0x204, 0x91, 0x20);  // SNE V1, V2 (not equal, skip)
+    emulate_cycle(); emulate_cycle(); emulate_cycle();
+    ASSERT_EQ("SNE skip: pc = 0x208", pc, 0x208);
+
+    setup(0x61, 0x0A);
+    inject(0x202, 0x62, 0x0A);
+    inject(0x204, 0x91, 0x20);  // SNE V1, V2 (equal, no skip)
+    emulate_cycle(); emulate_cycle(); emulate_cycle();
+    ASSERT_EQ("SNE no skip: pc = 0x206", pc, 0x206);
+}
+
+// ==================== ANNN: Set I ====================
+
+void test_ANNN() {
+    printf("== ANNN: LD I, addr ==\n");
+    setup(0xA3, 0x45);  // LD I, 0x345
+    emulate_cycle();
+    ASSERT_EQ("LD I = 0x345", I, 0x345);
+}
+
+// ==================== BNNN: Jump V0 + NNN ====================
+
+void test_BNNN() {
+    printf("== BNNN: JP V0, addr ==\n");
+    setup(0x60, 0x10);  // LD V0, 0x10
+    inject(0x202, 0xB3, 0x00);  // JP 0x300 + V0
+    emulate_cycle(); emulate_cycle();
+    ASSERT_EQ("JP V0: pc = 0x310", pc, 0x310);
+}
+
+// ==================== CXNN: Random ====================
+
+void test_CXNN() {
+    printf("== CXNN: RND Vx, byte ==\n");
+    setup(0xC1, 0x00);  // RND V1, 0x00 (always 0)
+    emulate_cycle();
+    ASSERT_EQ("RND mask 0x00: V1 = 0", V[1], 0);
+
+    // mask 0x0F: result should be 0x00-0x0F
+    setup(0xC1, 0x0F);
+    emulate_cycle();
+    ASSERT_EQ("RND mask 0x0F: upper nibble clear", V[1] & 0xF0, 0);
+}
+
+// ==================== DXYN: Draw Sprite ====================
+
+void test_DXYN() {
+    printf("== DXYN: DRW Vx, Vy, N ==\n");
+    // Draw a single row sprite (0xFF = 8 pixels on) at (0,0)
+    setup(0x60, 0x00);  // V0 = 0 (x)
+    inject(0x202, 0x61, 0x00);  // V1 = 0 (y)
+    inject(0x204, 0xA5, 0x00);  // I = 0x500
+    inject(0x206, 0xD0, 0x11);  // DRW V0, V1, 1
+    memory[0x500] = 0xFF;  // sprite data: all pixels on
+    emulate_cycle(); emulate_cycle(); emulate_cycle(); emulate_cycle();
+    ASSERT_EQ("DRW: gfx[0] = 1", gfx[0], 1);
+    ASSERT_EQ("DRW: gfx[7] = 1", gfx[7], 1);
+    ASSERT_EQ("DRW: gfx[8] = 0", gfx[8], 0);
+    ASSERT_EQ("DRW: VF = 0 (no collision)", V[0xF], 0);
+    ASSERT_EQ("DRW: draw_flag set", draw_flag, 1);
+}
+
+void test_DXYN_collision() {
+    printf("== DXYN: Collision detection ==\n");
+    setup(0x60, 0x00);
+    inject(0x202, 0x61, 0x00);
+    inject(0x204, 0xA5, 0x00);
+    inject(0x206, 0xD0, 0x11);  // DRW V0, V1, 1
+    memory[0x500] = 0x80;  // one pixel
+    gfx[0] = 1;  // pre-set pixel for collision
+    emulate_cycle(); emulate_cycle(); emulate_cycle(); emulate_cycle();
+    ASSERT_EQ("DRW collision: gfx[0] = 0 (XOR)", gfx[0], 0);
+    ASSERT_EQ("DRW collision: VF = 1", V[0xF], 1);
+}
+
+void test_DXYN_wrapping() {
+    printf("== DXYN: Coordinate wrapping & clipping ==\n");
+    // X coordinate wraps mod 64
+    setup(0x60, 0x45);  // V0 = 69 (wraps to 69 % 64 = 5)
+    inject(0x202, 0x61, 0x00);  // V1 = 0
+    inject(0x204, 0xA5, 0x00);
+    inject(0x206, 0xD0, 0x11);
+    memory[0x500] = 0x80;  // single pixel at leftmost
+    emulate_cycle(); emulate_cycle(); emulate_cycle(); emulate_cycle();
+    ASSERT_EQ("DRW X wrap: pixel at x=5", gfx[5], 1);
+
+    // Y coordinate wraps mod 32
+    setup(0x60, 0x00);
+    inject(0x202, 0x61, 0x23);  // V1 = 35 (wraps to 35 % 32 = 3)
+    inject(0x204, 0xA5, 0x00);
+    inject(0x206, 0xD0, 0x11);
+    memory[0x500] = 0x80;
+    emulate_cycle(); emulate_cycle(); emulate_cycle(); emulate_cycle();
+    ASSERT_EQ("DRW Y wrap: pixel at y=3", gfx[3 * 64], 1);
+
+    // Sprite clips at right edge (doesn't wrap around)
+    setup(0x60, 0x3D);  // V0 = 61
+    inject(0x202, 0x61, 0x00);
+    inject(0x204, 0xA5, 0x00);
+    inject(0x206, 0xD0, 0x11);
+    memory[0x500] = 0xFF;  // 8 pixels, but only 3 fit (61,62,63)
+    emulate_cycle(); emulate_cycle(); emulate_cycle(); emulate_cycle();
+    ASSERT_EQ("DRW clip: pixel at x=61", gfx[61], 1);
+    ASSERT_EQ("DRW clip: pixel at x=63", gfx[63], 1);
+    // pixel should not wrap to x=0
+    ASSERT_EQ("DRW clip: x=0 untouched", gfx[0], 0);
+}
+
+// ==================== EX9E / EXA1: Key skip ====================
+
+void test_EX9E() {
+    printf("== EX9E: SKP Vx ==\n");
+    setup(0x61, 0x05);  // V1 = 5
+    inject(0x202, 0xE1, 0x9E);  // SKP V1
+    keypad[5] = 1;
+    emulate_cycle(); emulate_cycle();
+    ASSERT_EQ("SKP pressed: pc = 0x206", pc, 0x206);
+
+    setup(0x61, 0x05);
+    inject(0x202, 0xE1, 0x9E);
+    keypad[5] = 0;
+    emulate_cycle(); emulate_cycle();
+    ASSERT_EQ("SKP not pressed: pc = 0x204", pc, 0x204);
+}
+
+void test_EXA1() {
+    printf("== EXA1: SKNP Vx ==\n");
+    setup(0x61, 0x05);
+    inject(0x202, 0xE1, 0xA1);  // SKNP V1
+    keypad[5] = 0;
+    emulate_cycle(); emulate_cycle();
+    ASSERT_EQ("SKNP not pressed: pc = 0x206", pc, 0x206);
+
+    setup(0x61, 0x05);
+    inject(0x202, 0xE1, 0xA1);
+    keypad[5] = 1;
+    emulate_cycle(); emulate_cycle();
+    ASSERT_EQ("SKNP pressed: pc = 0x204", pc, 0x204);
+}
+
+// ==================== FX07 / FX15: Delay timer ====================
+
+void test_FX07_FX15() {
+    printf("== FX07/FX15: Delay timer ==\n");
+    setup(0x61, 0x3C);  // LD V1, 60
+    inject(0x202, 0xF1, 0x15);  // LD DT, V1
+    emulate_cycle(); emulate_cycle();
+    ASSERT_EQ("set delay_timer = 60", delay_timer, 60);
+
+    inject(0x204, 0xF2, 0x07);  // LD V2, DT
+    emulate_cycle();
+    ASSERT_EQ("read delay_timer into V2", V[2], 60);
+}
+
+// ==================== FX18: Sound timer ====================
+
+void test_FX18() {
+    printf("== FX18: Sound timer ==\n");
+    setup(0x61, 0x0A);
+    inject(0x202, 0xF1, 0x18);  // LD ST, V1
+    emulate_cycle(); emulate_cycle();
+    ASSERT_EQ("set sound_timer = 10", sound_timer, 10);
+}
+
+// ==================== FX1E: Add I ====================
+
+void test_FX1E() {
+    printf("== FX1E: ADD I, Vx ==\n");
+    setup(0xA2, 0x00);  // I = 0x200
+    inject(0x202, 0x61, 0x10);  // V1 = 0x10
+    inject(0x204, 0xF1, 0x1E);  // ADD I, V1
+    emulate_cycle(); emulate_cycle(); emulate_cycle();
+    ASSERT_EQ("ADD I: I = 0x210", I, 0x210);
+}
+
+// ==================== FX29: Font sprite location ====================
+
+void test_FX29() {
+    printf("== FX29: LD F, Vx ==\n");
+    setup(0x61, 0x00);  // V1 = 0
+    inject(0x202, 0xF1, 0x29);  // LD F, V1
+    emulate_cycle(); emulate_cycle();
+    ASSERT_EQ("font 0: I = 0x50", I, 0x50);
+
+    setup(0x61, 0x0F);  // V1 = 0xF
+    inject(0x202, 0xF1, 0x29);
+    emulate_cycle(); emulate_cycle();
+    ASSERT_EQ("font F: I = 0x9B", I, 0x50 + 0xF * 5);
+}
+
+// ==================== FX33: BCD ====================
+
+void test_FX33() {
+    printf("== FX33: BCD ==\n");
+    setup(0x61, 0xFE);  // V1 = 254
+    inject(0x202, 0xA5, 0x00);  // I = 0x500
+    inject(0x204, 0xF1, 0x33);  // BCD V1
+    emulate_cycle(); emulate_cycle(); emulate_cycle();
+    ASSERT_EQ("BCD 254: hundreds = 2", memory[0x500], 2);
+    ASSERT_EQ("BCD 254: tens = 5", memory[0x501], 5);
+    ASSERT_EQ("BCD 254: ones = 4", memory[0x502], 4);
+
+    // test 0
+    setup(0x61, 0x00);
+    inject(0x202, 0xA5, 0x00);
+    inject(0x204, 0xF1, 0x33);
+    emulate_cycle(); emulate_cycle(); emulate_cycle();
+    ASSERT_EQ("BCD 0: hundreds = 0", memory[0x500], 0);
+    ASSERT_EQ("BCD 0: tens = 0", memory[0x501], 0);
+    ASSERT_EQ("BCD 0: ones = 0", memory[0x502], 0);
+}
+
+// ==================== FX55 / FX65: Store/Load registers ====================
+
+void test_FX55() {
+    printf("== FX55: LD [I], Vx ==\n");
+    init_cpu();
+    V[0] = 0xAA; V[1] = 0xBB; V[2] = 0xCC;
+    I = 0x500;
+    memory[0x200] = 0xF2; memory[0x201] = 0x55;  // LD [I], V2
+    emulate_cycle();
+    ASSERT_EQ("store V0", memory[0x500], 0xAA);
+    ASSERT_EQ("store V1", memory[0x501], 0xBB);
+    ASSERT_EQ("store V2", memory[0x502], 0xCC);
+    ASSERT_EQ("I unchanged", I, 0x500);
+}
+
+void test_FX65() {
+    printf("== FX65: LD Vx, [I] ==\n");
+    init_cpu();
+    I = 0x500;
+    memory[0x500] = 0x11; memory[0x501] = 0x22; memory[0x502] = 0x33;
+    memory[0x200] = 0xF2; memory[0x201] = 0x65;  // LD V2, [I]
+    emulate_cycle();
+    ASSERT_EQ("load V0", V[0], 0x11);
+    ASSERT_EQ("load V1", V[1], 0x22);
+    ASSERT_EQ("load V2", V[2], 0x33);
+    ASSERT_EQ("V3 untouched", V[3], 0);
+    ASSERT_EQ("I unchanged", I, 0x500);
+}
+
+// ==================== FX0A: Wait for key ====================
+
+void test_FX0A() {
+    printf("== FX0A: LD Vx, K (key wait) ==\n");
+    init_cpu();
+    memory[0x200] = 0xF1; memory[0x201] = 0x0A;  // LD V1, K
+
+    // no key pressed: pc should not advance
+    emulate_cycle();
+    ASSERT_EQ("no key: pc stays at 0x200", pc, 0x200);
+
+    // simulate key 5 press (with prev_keypad transition)
+    memset(prev_keypad, 0, sizeof(prev_keypad));
+    keypad[5] = 1;
+    emulate_cycle();
+    ASSERT_EQ("key pressed: pc still 0x200 (waiting for release)", pc, 0x200);
+    ASSERT_EQ("waiting_for_key = 5", waiting_for_key, 5);
+
+    // simulate key 5 release
+    keypad[5] = 0;
+    emulate_cycle();
+    ASSERT_EQ("key released: V1 = 5", V[1], 5);
+    ASSERT_EQ("key released: pc = 0x202", pc, 0x202);
+    ASSERT_EQ("waiting_for_key reset", waiting_for_key, -1);
+}
+
+// ==================== Timer update ====================
+
+void test_update_timers() {
+    printf("== update_timers ==\n");
+    init_cpu();
+    delay_timer = 5;
+    sound_timer = 3;
+
+    update_timers();
+    ASSERT_EQ("delay_timer decremented to 4", delay_timer, 4);
+    ASSERT_EQ("sound_timer decremented to 2", sound_timer, 2);
+    ASSERT_EQ("sound_flag set", sound_flag, 1);
+
+    // test timers don't go below 0
+    delay_timer = 0;
+    sound_timer = 0;
+    sound_flag = 0;
+    update_timers();
+    ASSERT_EQ("delay_timer stays 0", delay_timer, 0);
+    ASSERT_EQ("sound_timer stays 0", sound_timer, 0);
+    ASSERT_EQ("sound_flag not set when timer=0", sound_flag, 0);
+}
+
+// ==================== Main ====================
+
+int main(int argc, char **argv) {
+    test_init();
+    test_00E0();
+    test_2NNN_00EE();
+    test_nested_calls();
+    test_1NNN();
+    test_3XNN();
+    test_4XNN();
+    test_5XY0();
+    test_6XNN();
+    test_7XNN();
+    test_8XY0();
+    test_8XY1();
+    test_8XY2();
+    test_8XY3();
+    test_8XY4();
+    test_8XY4_vf_as_operand();
+    test_8XY5();
+    test_8XY6();
+    test_8XY7();
+    test_8XYE();
+    test_9XY0();
+    test_ANNN();
+    test_BNNN();
+    test_CXNN();
+    test_DXYN();
+    test_DXYN_collision();
+    test_DXYN_wrapping();
+    test_EX9E();
+    test_EXA1();
+    test_FX07_FX15();
+    test_FX18();
+    test_FX1E();
+    test_FX29();
+    test_FX33();
+    test_FX55();
+    test_FX65();
+    test_FX0A();
+    test_update_timers();
+
+    printf("\n=== Results: %d passed, %d failed ===\n", tests_passed, tests_failed);
+    return tests_failed > 0 ? 1 : 0;
 }

--- a/display.c
+++ b/display.c
@@ -3,11 +3,29 @@
 
 SDL_Window* screen;
 SDL_Renderer* renderer;
+// Standard CHIP-8 keypad mapping:
+// CHIP-8 key → Keyboard key
+// 1 2 3 C      1 2 3 4
+// 4 5 6 D      Q W E R
+// 7 8 9 E      A S D F
+// A 0 B F      Z X C V
 SDL_Scancode keymappings[16] = {
-        SDL_SCANCODE_1, SDL_SCANCODE_2, SDL_SCANCODE_3, SDL_SCANCODE_4,
-        SDL_SCANCODE_Q, SDL_SCANCODE_W, SDL_SCANCODE_E, SDL_SCANCODE_R,
-        SDL_SCANCODE_A, SDL_SCANCODE_S, SDL_SCANCODE_D, SDL_SCANCODE_F,
-        SDL_SCANCODE_Z, SDL_SCANCODE_X, SDL_SCANCODE_C, SDL_SCANCODE_V
+        SDL_SCANCODE_X, // 0
+        SDL_SCANCODE_1, // 1
+        SDL_SCANCODE_2, // 2
+        SDL_SCANCODE_3, // 3
+        SDL_SCANCODE_Q, // 4
+        SDL_SCANCODE_W, // 5
+        SDL_SCANCODE_E, // 6
+        SDL_SCANCODE_R, // 7
+        SDL_SCANCODE_A, // 8
+        SDL_SCANCODE_S, // 9
+        SDL_SCANCODE_D, // A
+        SDL_SCANCODE_F, // B
+        SDL_SCANCODE_Z, // C
+        SDL_SCANCODE_4, // D
+        SDL_SCANCODE_C, // E
+        SDL_SCANCODE_V  // F
 };
 int SHOULD_QUIT = 0;
 
@@ -48,22 +66,20 @@ void draw_screen(unsigned char* gfx) {
 void sdl_event_handler(unsigned char* keypad) {
     SDL_Event event;
 
-    if (SDL_PollEvent(&event)) {
-        const Uint8* state = SDL_GetKeyboardState(NULL);
-        switch (event.type) {
-            case SDL_QUIT:
-                SHOULD_QUIT = 1;
-                break;
-            default:
-                if (state[SDL_SCANCODE_ESCAPE]) {
-                    SHOULD_QUIT = 1;
-                }
-
-                for (int keycode = 0; keycode < 16; keycode++) {
-                    keypad[keycode] = state[keymappings[keycode]];
-                }
-                break;
+    while (SDL_PollEvent(&event)) {
+        if (event.type == SDL_QUIT) {
+            SHOULD_QUIT = 1;
+            return;
         }
+    }
+
+    const Uint8* state = SDL_GetKeyboardState(NULL);
+    if (state[SDL_SCANCODE_ESCAPE]) {
+        SHOULD_QUIT = 1;
+    }
+
+    for (int keycode = 0; keycode < 16; keycode++) {
+        keypad[keycode] = state[keymappings[keycode]];
     }
 }
 

--- a/emulator.c
+++ b/emulator.c
@@ -5,7 +5,7 @@
 #include "display.h"
 #include "sound.h"
 
-#define CYCLES_PER_FRAME 8
+#define CYCLES_PER_FRAME 16
 #define FRAME_DURATION_MS (1000 / 60) // ~16.67ms for 60 fps
 
 int main(int argc, char** argv) {
@@ -40,7 +40,7 @@ int main(int argc, char** argv) {
     while (1) {
         Uint32 frame_start = SDL_GetTicks();
 
-        // execute CPU cycles for this frame (~480 cycles/sec at 60 fps)
+        // execute CPU cycles for this frame (~960 cycles/sec at 60 fps)
         for (int i = 0; i < CYCLES_PER_FRAME; i++) {
             emulate_cycle();
         }

--- a/emulator.c
+++ b/emulator.c
@@ -1,8 +1,12 @@
 #include <stdio.h>
 #include <unistd.h>
+#include <SDL2/SDL.h>
 #include "chipee.h"
 #include "display.h"
 #include "sound.h"
+
+#define CYCLES_PER_FRAME 10
+#define TIMER_INTERVAL_MS (1000 / 60) // ~16.67ms for 60 Hz
 
 int main(int argc, char** argv) {
     if (argc != 2) {
@@ -22,7 +26,9 @@ int main(int argc, char** argv) {
     }
 
     // load ROM
-    load_rom(rom_filename);
+    if (!load_rom(rom_filename)) {
+        return 1;
+    }
 
     // initialize display
     init_chipee_display();
@@ -31,23 +37,40 @@ int main(int argc, char** argv) {
     init_chipee_sound();
 
     // game loop
+    Uint32 last_timer_tick = SDL_GetTicks();
+
     while (1) {
-        emulate_cycle();
+        // execute multiple CPU cycles per frame
+        for (int i = 0; i < CYCLES_PER_FRAME; i++) {
+            emulate_cycle();
+        }
+
         sdl_event_handler(keypad);
+        update_prev_keypad();
 
         if (should_quit()) {
             break;
         }
 
-        if (sound_flag) {
-            beep_sound();
+        // update timers at 60 Hz
+        Uint32 now = SDL_GetTicks();
+        if (now - last_timer_tick >= TIMER_INTERVAL_MS) {
+            update_timers();
+            last_timer_tick = now;
+        }
+
+        // manage sound based on sound_timer
+        if (sound_timer > 0) {
+            start_sound();
+        } else {
+            stop_sound();
         }
 
         if (draw_flag) {
             draw_screen(gfx);
         }
 
-        // hack to limit fps
+        // sleep to target ~60 fps
         usleep(1000);
     }
 

--- a/emulator.c
+++ b/emulator.c
@@ -52,15 +52,15 @@ int main(int argc, char** argv) {
             break;
         }
 
-        // update timers once per frame = 60 Hz
-        update_timers();
-
-        // manage sound based on sound_timer
+        // manage sound based on sound_timer (check before decrement)
         if (sound_timer > 0) {
             start_sound();
         } else {
             stop_sound();
         }
+
+        // update timers once per frame = 60 Hz
+        update_timers();
 
         if (draw_flag) {
             draw_screen(gfx);

--- a/emulator.c
+++ b/emulator.c
@@ -5,8 +5,8 @@
 #include "display.h"
 #include "sound.h"
 
-#define CYCLES_PER_FRAME 10
-#define TIMER_INTERVAL_MS (1000 / 60) // ~16.67ms for 60 Hz
+#define CYCLES_PER_FRAME 8
+#define FRAME_DURATION_MS (1000 / 60) // ~16.67ms for 60 fps
 
 int main(int argc, char** argv) {
     if (argc != 2) {
@@ -37,10 +37,10 @@ int main(int argc, char** argv) {
     init_chipee_sound();
 
     // game loop
-    Uint32 last_timer_tick = SDL_GetTicks();
-
     while (1) {
-        // execute multiple CPU cycles per frame
+        Uint32 frame_start = SDL_GetTicks();
+
+        // execute CPU cycles for this frame (~480 cycles/sec at 60 fps)
         for (int i = 0; i < CYCLES_PER_FRAME; i++) {
             emulate_cycle();
         }
@@ -52,12 +52,8 @@ int main(int argc, char** argv) {
             break;
         }
 
-        // update timers at 60 Hz
-        Uint32 now = SDL_GetTicks();
-        if (now - last_timer_tick >= TIMER_INTERVAL_MS) {
-            update_timers();
-            last_timer_tick = now;
-        }
+        // update timers once per frame = 60 Hz
+        update_timers();
 
         // manage sound based on sound_timer
         if (sound_timer > 0) {
@@ -70,8 +66,11 @@ int main(int argc, char** argv) {
             draw_screen(gfx);
         }
 
-        // sleep to target ~60 fps
-        usleep(1000);
+        // sleep remainder of frame to target 60 fps
+        Uint32 frame_time = SDL_GetTicks() - frame_start;
+        if (frame_time < FRAME_DURATION_MS) {
+            SDL_Delay(FRAME_DURATION_MS - frame_time);
+        }
     }
 
     stop_chipee_sound();

--- a/sound.c
+++ b/sound.c
@@ -40,7 +40,7 @@ void init_chipee_sound() {
     want.freq = 44100; // number of samples per second
     want.format = AUDIO_S16SYS;
     want.channels = 2;
-    want.samples = 2048; // buffer-size
+    want.samples = 512; // buffer-size (small for low-latency short beeps)
     want.callback = audio_callback; // function SDL calls periodically to refill the buffer
     want.userdata = &sample_nr; // counter, keeping track of current sample number
 

--- a/sound.c
+++ b/sound.c
@@ -16,14 +16,16 @@ void audio_callback(void *user_data, unsigned char *raw_buffer, int bytes) {
 
     for (int i = 0; i < length; i++, nr++) {
         double time = nr / sample_rate;
-        buffer[i] = (Sint16)(amplitude * sin(2.0f * M_PI * 441.0f * time)); // render 441 HZ sine wave
+        buffer[i] = (Sint16)(amplitude * sin(2.0f * M_PI * 440.0f * time)); // render 440 Hz sine wave
     }
 }
 
-void beep_sound() {
-    SDL_PauseAudio(0); // start playing sound
-    SDL_Delay(25); // wait while sound is playing
-    SDL_PauseAudio(1); // stop playing sound
+void start_sound() {
+    SDL_PauseAudio(0);
+}
+
+void stop_sound() {
+    SDL_PauseAudio(1);
 }
 
 void init_chipee_sound() {

--- a/sound.h
+++ b/sound.h
@@ -5,7 +5,8 @@ void init_chipee_sound();
 
 void audio_callback(void *user_data, unsigned char *raw_buffer, int bytes);
 
-void beep_sound();
+void start_sound();
+void stop_sound();
 
 void stop_chipee_sound();
 


### PR DESCRIPTION
## Summary
This PR adds an extensive test suite for the CHIP-8 emulator and fixes several critical bugs in the CPU implementation, timer handling, and display/input management.

## Key Changes

### Test Suite (chipee_tests.c)
- Replaced minimal ad-hoc tests with 40+ comprehensive unit tests covering:
  - CPU initialization and state verification
  - All major opcodes (0x00E0, 0x2NNN/0x00EE, 0x1NNN, 0x3XNN-0x9XY0, 0xANNN-0xFX65)
  - Arithmetic operations with carry/borrow flags
  - Bitwise operations (OR, AND, XOR)
  - Shift operations (SHR, SHL) with proper flag handling
  - Draw sprite (DXYN) with collision detection and coordinate wrapping
  - Key input handling (EX9E, EXA1, FX0A)
  - Timer operations (FX07, FX15, FX18)
  - Memory operations (FX55, FX65, FX33 BCD)
  - Nested subroutine calls
- Added test infrastructure with ASSERT_EQ macro and pass/fail counters

### CPU Implementation (chipee.c)
- **Fixed stack operations**: Corrected order of sp increment/decrement in CALL (0x2NNN) and RET (0x00EE) to prevent off-by-one errors
- **Added stack bounds checking**: Detect and report stack overflow/underflow
- **Fixed arithmetic flags**: 
  - 0x8XY4 (ADD): Use unsigned arithmetic to properly detect overflow
  - 0x8XY5 (SUB): Changed VF logic from `V[x] > V[y]` to `V[x] >= V[y]` (no borrow when equal)
  - 0x8XY7 (SUBN): Same fix for reverse subtraction
  - 0x8XY6 (SHR): Extract LSB before shift, not after
  - 0x8XYE (SHL): Extract MSB before shift, not after
- **Fixed logical operations**: Reset VF to 0 for OR, AND, XOR operations
- **Fixed CLS (0x00E0)**: Set draw_flag when clearing screen
- **Improved ROM loading**: Added size validation and proper error handling
- **Enhanced init_cpu()**: Complete state reset including memory, registers, timers, and keypad

### Timer and Input Management (emulator.c, chipee.c)
- **Frame timing**: Execute 16 CPU cycles per frame at 60 FPS (~960 cycles/sec)
- **Timer updates**: Call update_timers() once per frame (60 Hz) instead of per cycle
- **Sound management**: Separate start_sound() and stop_sound() functions; play sound when sound_timer > 0
- **Key input tracking**: Added prev_keypad state and waiting_for_key variable for FX0A (key wait) instruction
- **Added update_prev_keypad()** function to track key state transitions

### Display and Input (display.c)
- **Fixed keypad mapping**: Corrected CHIP-8 to keyboard mapping (X=0, 1-3=1-3, Q-R=4-7, A-F=8-B, Z-V=C,D,E,F)
- **Improved event handling**: Changed from single SDL_PollEvent to while loop for proper event queue processing
- **Separated input update**: Keypad state now updated every frame regardless of events

### Sound (sound.h, sound.c)
- **Refactored audio control**: Split beep_sound() into start_sound() and stop_sound() for continuous sound during timer
- **Fixed frequency**: Changed from 441 Hz to standard 440 Hz (A4 note)

### Header Updates (chipee.h)
- Added extern declarations for prev_keypad and waiting_for_key

## Notable Implementation Details
- Tests use helper functions (setup, inject) to reduce boilerplate
- Arithmetic operations now properly handle 8-bit

https://claude.ai/code/session_0191op7YXAkb1mqxa8QCoyVA