### PR TITLE
Fix draw_flag being lost when running multiple cycles per frame

### DIFF
--- a/chipee.c
+++ b/chipee.c
@@ -130,8 +130,6 @@ int load_rom(char* filename) {
 }
 
 void emulate_cycle() {
-    draw_flag = 0;
-    sound_flag = 0;
     unsigned short op = memory[pc] << 8 | memory[pc + 1];
     unsigned short x = (op & 0x0F00) >> 8;
     unsigned short y = (op & 0x00F0) >> 4;

--- a/emulator.c
+++ b/emulator.c
@@ -64,6 +64,7 @@ int main(int argc, char** argv) {
 
         if (draw_flag) {
             draw_screen(gfx);
+            draw_flag = 0;
         }
 
         // sleep remainder of frame to target 60 fps


### PR DESCRIPTION
With 16 cycles per frame, draw_flag was reset to 0 at the start of every emulate_cycle(). This meant only the last cycle's draw_flag survived to the main loop check. Programs that finish drawing and enter an idle loop (like the logo ROM) would never get their final frame rendered, since non-draw instructions after the last DRW would clear the flag.

Fix: remove draw_flag reset from emulate_cycle() and instead reset it in the main loop after draw_screen() is called. This lets draw_flag accumulate across cycles within a frame — any DRW or CLS in the batch triggers a screen update.